### PR TITLE
Add Alias Project Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,82 @@ db.my_collection.aggregate([{
   "$sort": {
     "count": -1
   }
+},{
+  "$project": {
+    "borough": "$_id.borough",
+    "cuisine": "$_id.cuisine",
+    "count": 1,
+    "_id": 0
+  }
+}])
+```
+
+###Alias
+
+```
+select object.key1 as key1, object2.key3 as key3, object1.key4 as key4 from my_collection where object.key2 = 34 AND object2.key4 > 5;
+
+
+******Mongo Query:*********
+
+db.Restaurants.aggregate([{
+  "$match": {
+    "$and": [
+      {
+        "Restaurant.cuisine": "American"
+      },
+      {
+        "Restaurant.borough": {
+          "$gt": "N"
+        }
+      }
+    ]
+  }
+},{
+  "$project": {
+    "_id": 0,
+    "key1": "$Restaurant.borough",
+    "key3": "$Restaurant.cuisine",
+    "key4": "$Restaurant.address.zipcode"
+  }
+}])
+```
+
+###Alias Group By (Aggregation)
+
+```
+select borough as b, cuisine as c, count(*) as co from my_collection WHERE borough LIKE 'Queens%' GROUP BY borough, cuisine ORDER BY count(*) DESC;
+
+
+******Mongo Query:*********
+
+db.my_collection.aggregate([{
+  "$match": {
+    "borough": {
+      "$regex": "^Queens.*$"
+    }
+  }
+},{
+  "$group": {
+    "_id": {
+      "borough": "$borough",
+      "cuisine": "$cuisine"
+    },
+    "co": {
+      "$sum": 1
+    }
+  }
+},{
+  "$sort": {
+    "co": -1
+  }
+},{
+  "$project": {
+    "b": "$_id.borough",
+    "c": "$_id.cuisine",
+    "co": 1,
+    "_id": 0
+  }
 }])
 ```
 
@@ -329,67 +405,47 @@ select borough, cuisine, count(*) from my_collection GROUP BY borough, cuisine O
 ******Query Results:*********
 
 [{
-	"_id" : {
-		"borough" : "Manhattan",
-		"cuisine" : "American "
-	},
+	"borough" : "Manhattan",
+	"cuisine" : "American ",
 	"count" : 3205
 },{
-	"_id" : {
-		"borough" : "Brooklyn",
-		"cuisine" : "American "
-	},
+	"borough" : "Brooklyn",
+	"cuisine" : "American ",
 	"count" : 1273
 },{
-	"_id" : {
-		"borough" : "Queens",
-		"cuisine" : "American "
-	},
+	"borough" : "Queens",
+	"cuisine" : "American ",
 	"count" : 1040
 },{
-	"_id" : {
-		"borough" : "Brooklyn",
-		"cuisine" : "Chinese"
-	},
+	"borough" : "Brooklyn",
+	"cuisine" : "Chinese",
 	"count" : 763
 },{
-	"_id" : {
-		"borough" : "Queens",
-		"cuisine" : "Chinese"
-	},
+	"borough" : "Queens",
+	"cuisine" : "Chinese",
 	"count" : 728
 }]
 
 more results? (y/n): y
 [{
-	"_id" : {
-		"borough" : "Manhattan",
-		"cuisine" : "Café/Coffee/Tea"
-	},
+	"borough" : "Manhattan",
+	"cuisine" : "Café/Coffee/Tea",
 	"count" : 680
 },{
-	"_id" : {
-		"borough" : "Manhattan",
-		"cuisine" : "Italian"
-	},
+	"borough" : "Manhattan",
+	"cuisine" : "Italian",
 	"count" : 621
 },{
-	"_id" : {
-		"borough" : "Manhattan",
-		"cuisine" : "Chinese"
-	},
+	"borough" : "Manhattan",
+	"cuisine" : "Chinese",
 	"count" : 510
 },{
-	"_id" : {
-		"borough" : "Manhattan",
-		"cuisine" : "Japanese"
-	},
+	"borough" : "Manhattan",
+	"cuisine" : "Japanese",
 	"count" : 438
 },{
-	"_id" : {
-		"borough" : "Bronx",
-		"cuisine" : "American "
-	},
+	"borough" : "Bronx",
+	"cuisine" : "American ",
 	"count" : 411
 }]
 

--- a/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/MongoDBQueryHolder.java
+++ b/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/MongoDBQueryHolder.java
@@ -2,6 +2,7 @@ package com.github.vincentrussell.query.mongodb.sql.converter;
 
 import org.bson.Document;
 
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,6 +14,7 @@ public class MongoDBQueryHolder {
     private Document query = new Document();
     private Document projection = new Document();
     private Document sort = new Document();
+    private Document aliasProjection = new Document();
     private boolean distinct = false;
     private boolean countAll = false;
     private List<String> groupBys = new ArrayList<>();
@@ -95,6 +97,14 @@ public class MongoDBQueryHolder {
     public List<String> getGroupBys() {
         return groupBys;
     }
+    
+	public Document getAliasProjection() {
+		return aliasProjection;
+	}
+
+	public void setAliasProjection(Document aliasProjection) {
+		this.aliasProjection = aliasProjection;
+	}
 
     public long getLimit() {
         return limit;
@@ -107,4 +117,5 @@ public class MongoDBQueryHolder {
     public SQLCommandType getSqlCommandType() {
         return sqlCommandType;
     }
+    
 }

--- a/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
+++ b/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
@@ -332,8 +332,8 @@ public class QueryConverterIT {
         		"	\"count\" : 51,\n" + 
         		"	\"borough\" : \"Missing\"\n" + 
         		"},{\n" + 
-        		"	\"count\" : 5656,\n" + 
-        		"	\"borough\" : \"Queens\"\n" + 
+        		"	\"count\" : 969,\n" + 
+        		"	\"borough\" : \"Staten Island\"\n" + 
         		"},{\n" + 
         		"	\"count\" : 10259,\n" + 
         		"	\"borough\" : \"Manhattan\"\n" + 
@@ -341,11 +341,11 @@ public class QueryConverterIT {
         		"	\"count\" : 6086,\n" + 
         		"	\"borough\" : \"Brooklyn\"\n" + 
         		"},{\n" + 
+        		"	\"count\" : 5656,\n" + 
+        		"	\"borough\" : \"Queens\"\n" + 
+        		"},{\n" + 
         		"	\"count\" : 2338,\n" + 
         		"	\"borough\" : \"Bronx\"\n" + 
-        		"},{\n" + 
-        		"	\"count\" : 969,\n" + 
-        		"	\"borough\" : \"Staten Island\"\n" + 
         		"}]",toJson(results));
     }
 
@@ -508,7 +508,7 @@ public class QueryConverterIT {
         List<Document> results = Lists.newArrayList(distinctIterable);
         assertEquals(2, results.size());
         assertEquals(Arrays.asList(new Document("count",51).append("borough","Missing"),
-                new Document("count",5656).append("borough","Queens")
+                new Document("count",969).append("borough","Staten Island")
         ),results);
     }
 
@@ -527,37 +527,37 @@ public class QueryConverterIT {
         }));
 
         assertEquals("[{\n" + 
+        		"	\"count\" : 680,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
+        		"},{\n" + 
         		"	\"count\" : 510,\n" + 
         		"	\"borough\" : \"Manhattan\",\n" + 
         		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"count\" : 1273,\n" + 
-        		"	\"borough\" : \"Brooklyn\",\n" + 
-        		"	\"cuisine\" : \"American \"\n" + 
+        		"	\"count\" : 728,\n" + 
+        		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
         		"	\"count\" : 1040,\n" + 
         		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 3205,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 1273,\n" + 
+        		"	\"borough\" : \"Brooklyn\",\n" + 
         		"	\"cuisine\" : \"American \"\n" + 
         		"},{\n" + 
         		"	\"count\" : 763,\n" + 
         		"	\"borough\" : \"Brooklyn\",\n" + 
         		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"count\" : 3205,\n" + 
-        		"	\"borough\" : \"Manhattan\",\n" + 
-        		"	\"cuisine\" : \"American \"\n" + 
-        		"},{\n" + 
-        		"	\"count\" : 728,\n" + 
-        		"	\"borough\" : \"Queens\",\n" + 
-        		"	\"cuisine\" : \"Chinese\"\n" + 
-        		"},{\n" + 
         		"	\"count\" : 621,\n" + 
         		"	\"borough\" : \"Manhattan\",\n" + 
         		"	\"cuisine\" : \"Italian\"\n" + 
-        		"},{\n" + 
-        		"	\"count\" : 680,\n" + 
-        		"	\"borough\" : \"Manhattan\",\n" + 
-        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
         		"}]",toJson(filteredResults));
     }
     
@@ -576,37 +576,37 @@ public class QueryConverterIT {
         }));
 
         assertEquals("[{\n" + 
+        		"	\"co\" : 680,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
+        		"},{\n" + 
         		"	\"co\" : 510,\n" + 
         		"	\"b\" : \"Manhattan\",\n" + 
         		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"co\" : 1273,\n" + 
-        		"	\"b\" : \"Brooklyn\",\n" + 
-        		"	\"cuisine\" : \"American \"\n" + 
+        		"	\"co\" : 728,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
         		"	\"co\" : 1040,\n" + 
         		"	\"b\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 3205,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1273,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
         		"	\"cuisine\" : \"American \"\n" + 
         		"},{\n" + 
         		"	\"co\" : 763,\n" + 
         		"	\"b\" : \"Brooklyn\",\n" + 
         		"	\"cuisine\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"co\" : 3205,\n" + 
-        		"	\"b\" : \"Manhattan\",\n" + 
-        		"	\"cuisine\" : \"American \"\n" + 
-        		"},{\n" + 
-        		"	\"co\" : 728,\n" + 
-        		"	\"b\" : \"Queens\",\n" + 
-        		"	\"cuisine\" : \"Chinese\"\n" + 
-        		"},{\n" + 
         		"	\"co\" : 621,\n" + 
         		"	\"b\" : \"Manhattan\",\n" + 
         		"	\"cuisine\" : \"Italian\"\n" + 
-        		"},{\n" + 
-        		"	\"co\" : 680,\n" + 
-        		"	\"b\" : \"Manhattan\",\n" + 
-        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
         		"}]",toJson(filteredResults));
     }
     
@@ -625,37 +625,37 @@ public class QueryConverterIT {
         }));
 
         assertEquals("[{\n" + 
+        		"	\"co\" : 680,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"Café/Coffee/Tea\"\n" + 
+        		"},{\n" + 
         		"	\"co\" : 510,\n" + 
         		"	\"b\" : \"Manhattan\",\n" + 
         		"	\"c\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"co\" : 1273,\n" + 
-        		"	\"b\" : \"Brooklyn\",\n" + 
-        		"	\"c\" : \"American \"\n" + 
+        		"	\"co\" : 728,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"Chinese\"\n" + 
         		"},{\n" + 
         		"	\"co\" : 1040,\n" + 
         		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 3205,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1273,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
         		"	\"c\" : \"American \"\n" + 
         		"},{\n" + 
         		"	\"co\" : 763,\n" + 
         		"	\"b\" : \"Brooklyn\",\n" + 
         		"	\"c\" : \"Chinese\"\n" + 
         		"},{\n" + 
-        		"	\"co\" : 3205,\n" + 
-        		"	\"b\" : \"Manhattan\",\n" + 
-        		"	\"c\" : \"American \"\n" + 
-        		"},{\n" + 
-        		"	\"co\" : 728,\n" + 
-        		"	\"b\" : \"Queens\",\n" + 
-        		"	\"c\" : \"Chinese\"\n" + 
-        		"},{\n" + 
         		"	\"co\" : 621,\n" + 
         		"	\"b\" : \"Manhattan\",\n" + 
         		"	\"c\" : \"Italian\"\n" + 
-        		"},{\n" + 
-        		"	\"co\" : 680,\n" + 
-        		"	\"b\" : \"Manhattan\",\n" + 
-        		"	\"c\" : \"Café/Coffee/Tea\"\n" + 
         		"}]",toJson(filteredResults));
     }
 

--- a/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
+++ b/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
@@ -201,6 +201,126 @@ public class QueryConverterIT {
         assertEquals(5, results.size());
         assertEquals(Arrays.asList("Manhattan", "Queens", "Brooklyn", "Bronx", "Staten Island"),results);
     }
+    
+    @Test
+    public void selectQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough, cuisine from "+COLLECTION+" limit 6");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Bakery\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"Hamburgers\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Irish\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"Jewish/Kosher\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"}]",toJson(results));
+    }
+    
+    @Test
+    public void selectQueryAlias() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough as b, cuisine as c from "+COLLECTION+" limit 6");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"Bakery\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"c\" : \"Hamburgers\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"Irish\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"Jewish/Kosher\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"}]",toJson(results));
+    }
+    
+    @Test
+    public void selectOrderByQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough, cuisine from "+COLLECTION+" order by borough asc,cuisine desc limit 10");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(10, results.size());
+        assertEquals("[{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Thai\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Thai\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"}]",toJson(results));
+    }
+    
+    @Test
+    public void selectOrderByAliasQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough as b, cuisine as c from "+COLLECTION+" order by borough asc,cuisine asc limit 6");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"},{\n" + 
+        		"	\"b\" : \"Bronx\",\n" + 
+        		"	\"c\" : \"African\"\n" + 
+        		"}]",toJson(results));
+    }
 
     @Test
     public void countGroupByQuery() throws ParseException, IOException {
@@ -208,53 +328,177 @@ public class QueryConverterIT {
         QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
         List<Document> results = Lists.newArrayList(distinctIterable);
         assertEquals(6, results.size());
-        assertEquals("[{\n" +
-                "\t\"_id\" : \"Missing\",\n" +
-                "\t\"count\" : 51\n" +
-                "},{\n" +
-                "\t\"_id\" : \"Staten Island\",\n" +
-                "\t\"count\" : 969\n" +
-                "},{\n" +
-                "\t\"_id\" : \"Manhattan\",\n" +
-                "\t\"count\" : 10259\n" +
-                "},{\n" +
-                "\t\"_id\" : \"Bronx\",\n" +
-                "\t\"count\" : 2338\n" +
-                "},{\n" +
-                "\t\"_id\" : \"Queens\",\n" +
-                "\t\"count\" : 5656\n" +
-                "},{\n" +
-                "\t\"_id\" : \"Brooklyn\",\n" +
-                "\t\"count\" : 6086\n" +
-                "}]",toJson(results));
+        assertEquals("[{\n" + 
+        		"	\"count\" : 51,\n" + 
+        		"	\"borough\" : \"Missing\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 5656,\n" + 
+        		"	\"borough\" : \"Queens\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 10259,\n" + 
+        		"	\"borough\" : \"Manhattan\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 6086,\n" + 
+        		"	\"borough\" : \"Brooklyn\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 2338,\n" + 
+        		"	\"borough\" : \"Bronx\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 969,\n" + 
+        		"	\"borough\" : \"Staten Island\"\n" + 
+        		"}]",toJson(results));
     }
 
     @Test
-    public void countGroupByQuerySortByCount() throws ParseException, IOException {
+    public void countGroupBySortByCountQuery() throws ParseException, IOException {
         QueryConverter queryConverter = new QueryConverter("select borough, count(borough) from "+COLLECTION+" GROUP BY borough\n" +
                 "ORDER BY count(borough) DESC;");
         QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
         List<Document> results = Lists.newArrayList(distinctIterable);
         assertEquals(6, results.size());
         assertEquals("[{\n" +
-                "\t\"_id\" : \"Manhattan\",\n" +
-                "\t\"count\" : 10259\n" +
+                "\t\"count\" : 10259,\n" +
+                "\t\"borough\" : \"Manhattan\"\n" +
                 "},{\n" +
-                "\t\"_id\" : \"Brooklyn\",\n" +
-                "\t\"count\" : 6086\n" +
+                "\t\"count\" : 6086,\n" +
+                "\t\"borough\" : \"Brooklyn\"\n" +
                 "},{\n" +
-                "\t\"_id\" : \"Queens\",\n" +
-                "\t\"count\" : 5656\n" +
+                "\t\"count\" : 5656,\n" +
+                "\t\"borough\" : \"Queens\"\n" +
                 "},{\n" +
-                "\t\"_id\" : \"Bronx\",\n" +
-                "\t\"count\" : 2338\n" +
+                "\t\"count\" : 2338,\n" +
+                "\t\"borough\" : \"Bronx\"\n" +
                 "},{\n" +
-                "\t\"_id\" : \"Staten Island\",\n" +
-                "\t\"count\" : 969\n" +
+                "\t\"count\" : 969,\n" +
+                "\t\"borough\" : \"Staten Island\"\n" +
                 "},{\n" +
-                "\t\"_id\" : \"Missing\",\n" +
-                "\t\"count\" : 51\n" +
+                "\t\"count\" : 51,\n" +
+                "\t\"borough\" : \"Missing\"\n" +
                 "}]",toJson(results));
+    }
+    
+    @Test
+    public void countGroupBySortByCountAliasMixedQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough, count(borough) as co from "+COLLECTION+" GROUP BY borough\n" +
+                "ORDER BY count(borough) DESC;");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" +
+                "\t\"co\" : 10259,\n" +
+                "\t\"borough\" : \"Manhattan\"\n" +
+                "},{\n" +
+                "\t\"co\" : 6086,\n" +
+                "\t\"borough\" : \"Brooklyn\"\n" +
+                "},{\n" +
+                "\t\"co\" : 5656,\n" +
+                "\t\"borough\" : \"Queens\"\n" +
+                "},{\n" +
+                "\t\"co\" : 2338,\n" +
+                "\t\"borough\" : \"Bronx\"\n" +
+                "},{\n" +
+                "\t\"co\" : 969,\n" +
+                "\t\"borough\" : \"Staten Island\"\n" +
+                "},{\n" +
+                "\t\"co\" : 51,\n" +
+                "\t\"borough\" : \"Missing\"\n" +
+                "}]",toJson(results));
+    }
+    
+    @Test
+    public void countGroupBySortByCountAliasAllQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough b, count(borough) as co from "+COLLECTION+" GROUP BY borough\n" +
+                "ORDER BY count(borough) DESC;");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" +
+                "\t\"co\" : 10259,\n" +
+                "\t\"b\" : \"Manhattan\"\n" +
+                "},{\n" +
+                "\t\"co\" : 6086,\n" +
+                "\t\"b\" : \"Brooklyn\"\n" +
+                "},{\n" +
+                "\t\"co\" : 5656,\n" +
+                "\t\"b\" : \"Queens\"\n" +
+                "},{\n" +
+                "\t\"co\" : 2338,\n" +
+                "\t\"b\" : \"Bronx\"\n" +
+                "},{\n" +
+                "\t\"co\" : 969,\n" +
+                "\t\"b\" : \"Staten Island\"\n" +
+                "},{\n" +
+                "\t\"co\" : 51,\n" +
+                "\t\"b\" : \"Missing\"\n" +
+                "}]",toJson(results));
+    }
+    
+    @Test
+    public void countGroupByNestedFieldSortByCountAliasAllQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select address.zipcode as az, count(borough) as co from "+COLLECTION+" GROUP BY address.zipcode order by address.zipcode asc limit 6\n" +
+                "ORDER BY count(borough) DESC;");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"az\" : \"\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"az\" : \"07005\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"az\" : \"10000\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 520,\n" + 
+        		"	\"az\" : \"10001\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 471,\n" + 
+        		"	\"az\" : \"10002\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 686,\n" + 
+        		"	\"az\" : \"10003\"\n" + 
+        		"}]",toJson(results));
+    }
+    
+    @Test
+    public void countGroupByNestedFieldSortByCountQuery() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select address.zipcode, count(borough) as co from "+COLLECTION+" GROUP BY address.zipcode order by address.zipcode limit 6\n" +
+                "ORDER BY count(borough) DESC;");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(6, results.size());
+        assertEquals("[{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"\"\n" + 
+        		"	}\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"07005\"\n" + 
+        		"	}\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"10000\"\n" + 
+        		"	}\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 520,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"10001\"\n" + 
+        		"	}\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 471,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"10002\"\n" + 
+        		"	}\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 686,\n" + 
+        		"	\"address\" : {\n" + 
+        		"		\"zipcode\" : \"10003\"\n" + 
+        		"	}\n" + 
+        		"}]",toJson(results));
     }
 
     @Test
@@ -263,8 +507,8 @@ public class QueryConverterIT {
         QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
         List<Document> results = Lists.newArrayList(distinctIterable);
         assertEquals(2, results.size());
-        assertEquals(Arrays.asList(new Document("_id","Missing").append("count",51),
-                new Document("_id","Staten Island").append("count",969)
+        assertEquals(Arrays.asList(new Document("count",51).append("borough","Missing"),
+                new Document("count",5656).append("borough","Queens")
         ),results);
     }
 
@@ -282,55 +526,137 @@ public class QueryConverterIT {
             }
         }));
 
-        assertEquals("[{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Manhattan\",\n" +
-                "\t\t\"cuisine\" : \"Chinese\"\n" +
-                "\t},\n" +
-                "\t\"count\" : 510\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Queens\",\n" +
-                "\t\t\"cuisine\" : \"American \"\n" +
-                "\t},\n" +
-                "\t\"count\" : 1040\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Manhattan\",\n" +
-                "\t\t\"cuisine\" : \"Café/Coffee/Tea\"\n" +
-                "\t},\n" +
-                "\t\"count\" : 680\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Manhattan\",\n" +
-                "\t\t\"cuisine\" : \"Italian\"\n" +
-                "\t},\n" +
-                "\t\"count\" : 621\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Brooklyn\",\n" +
-                "\t\t\"cuisine\" : \"American \"\n" +
-                "\t},\n" +
-                "\t\"count\" : 1273\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Manhattan\",\n" +
-                "\t\t\"cuisine\" : \"American \"\n" +
-                "\t},\n" +
-                "\t\"count\" : 3205\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Queens\",\n" +
-                "\t\t\"cuisine\" : \"Chinese\"\n" +
-                "\t},\n" +
-                "\t\"count\" : 728\n" +
-                "},{\n" +
-                "\t\"_id\" : {\n" +
-                "\t\t\"borough\" : \"Brooklyn\",\n" +
-                "\t\t\"cuisine\" : \"Chinese\"\n" +
-                "\t},\n" +
-                "\t\"count\" : 763\n" +
-                "}]",toJson(filteredResults));
+        assertEquals("[{\n" + 
+        		"	\"count\" : 510,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 1273,\n" + 
+        		"	\"borough\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 1040,\n" + 
+        		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 763,\n" + 
+        		"	\"borough\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 3205,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 728,\n" + 
+        		"	\"borough\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 621,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Italian\"\n" + 
+        		"},{\n" + 
+        		"	\"count\" : 680,\n" + 
+        		"	\"borough\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
+        		"}]",toJson(filteredResults));
+    }
+    
+    @Test
+    public void countGroupByQueryMultipleColumnsAliasMixed() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough as b, cuisine, count(*) as co from "+COLLECTION+" GROUP BY borough, cuisine");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(365, results.size());
+
+        List<Document> filteredResults = Lists.newArrayList(Collections2.filter(results, new Predicate<Document>() {
+            @Override
+            public boolean apply(Document document) {
+                return document.getInteger("co") > 500;
+            }
+        }));
+
+        assertEquals("[{\n" + 
+        		"	\"co\" : 510,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1273,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1040,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 763,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 3205,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 728,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"cuisine\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 621,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Italian\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 680,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"cuisine\" : \"Café/Coffee/Tea\"\n" + 
+        		"}]",toJson(filteredResults));
+    }
+    
+    @Test
+    public void countGroupByQueryMultipleColumnsAliasAll() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough as b, cuisine as c, count(*) as co from "+COLLECTION+" GROUP BY borough, cuisine");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(365, results.size());
+
+        List<Document> filteredResults = Lists.newArrayList(Collections2.filter(results, new Predicate<Document>() {
+            @Override
+            public boolean apply(Document document) {
+                return document.getInteger("co") > 500;
+            }
+        }));
+
+        assertEquals("[{\n" + 
+        		"	\"co\" : 510,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1273,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 1040,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 763,\n" + 
+        		"	\"b\" : \"Brooklyn\",\n" + 
+        		"	\"c\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 3205,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"American \"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 728,\n" + 
+        		"	\"b\" : \"Queens\",\n" + 
+        		"	\"c\" : \"Chinese\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 621,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"Italian\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 680,\n" + 
+        		"	\"b\" : \"Manhattan\",\n" + 
+        		"	\"c\" : \"Café/Coffee/Tea\"\n" + 
+        		"}]",toJson(filteredResults));
     }
 
     @Test

--- a/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterTest.java
+++ b/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterTest.java
@@ -966,6 +966,12 @@ public class QueryConverterTest {
                 "      \"$sum\": \"$advance_amount\"\n" +
                 "    }\n" +
                 "  }\n" +
+                "},{\n" +
+				"  \"$project\": {\n" +
+				"    \"agent_code\": \"$_id\",\n" +
+				"    \"sum\": 1,\n" +
+				"    \"_id\": 0\n" +
+				"  }\n" +
                 "}])",byteArrayOutputStream.toString("UTF-8"));
     }
 
@@ -992,6 +998,12 @@ public class QueryConverterTest {
                 "    \"sum_advance_amount\": {\n" +
                 "      \"$sum\": \"$advance_amount\"\n" +
                 "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"agent_code\": \"$_id\",\n" +
+                "    \"sum\": 1,\n" +
+                "    \"_id\": 0\n" +
                 "  }\n" +
                 "}],{\n" +
                 "  \"allowDiskUse\": true,\n" +
@@ -1028,9 +1040,215 @@ public class QueryConverterTest {
                 "  \"$sort\": {\n" +
                 "    \"count\": -1\n" +
                 "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"agent_code\": \"$_id\",\n" +
+                "    \"count\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
+                "}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeSumGroupByWithSortWithAlias() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("SELECT agent_code as ac,   \n" +
+                "COUNT (advance_amount) as c  \n" +
+                "FROM orders \n " +
+                "WHERE agent_code LIKE 'AW_%'\n" +
+                "GROUP BY agent_code\n" +
+                "ORDER BY COUNT (advance_amount) DESC;");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.orders.aggregate([{\n" +
+                "  \"$match\": {\n" +
+                "    \"agent_code\": {\n" +
+                "      \"$regex\": \"^AW.{1}.*$\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$group\": {\n" +
+                "    \"_id\": \"$agent_code\",\n" +
+                "    \"c\": {\n" +
+                "      \"$sum\": 1\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$sort\": {\n" +
+                "    \"c\": -1\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"ac\": \"$_id\",\n" +
+                "    \"c\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
+                "}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeSumGroupByWithSortCountWithMultiAlias() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("SELECT agent_code as ac, city_code as cc,  \n" +
+                "COUNT (advance_amount) as c  \n" +
+                "FROM orders \n " +
+                "WHERE agent_code LIKE 'AW_%'\n" +
+                "GROUP BY agent_code, city_code\n" +
+                "ORDER BY COUNT (advance_amount) DESC;");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.orders.aggregate([{\n" +
+                "  \"$match\": {\n" +
+                "    \"agent_code\": {\n" +
+                "      \"$regex\": \"^AW.{1}.*$\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$group\": {\n" +
+                "    \"_id\": {\n" + 
+                "      \"agent_code\": \"$agent_code\",\n" +
+                "      \"city_code\": \"$city_code\"\n" +
+                "    },\n" +
+                "    \"c\": {\n" +
+                "      \"$sum\": 1\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$sort\": {\n" +
+                "    \"c\": -1\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"ac\": \"$_id.agent_code\",\n" +
+                "    \"cc\": \"$_id.city_code\",\n" +
+                "    \"c\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
+                "}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeSumGroupByWithSortFieldsWithMultiAlias() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("SELECT agent_code as ac, city_code as cc,  \n" +
+                "COUNT (advance_amount) as c  \n" +
+                "FROM orders \n " +
+                "WHERE agent_code LIKE 'AW_%'\n" +
+                "GROUP BY agent_code, city_code\n" +
+                "ORDER BY agent_code asc, city_code DESC;");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.orders.aggregate([{\n" +
+                "  \"$match\": {\n" +
+                "    \"agent_code\": {\n" +
+                "      \"$regex\": \"^AW.{1}.*$\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$group\": {\n" +
+                "    \"_id\": {\n" + 
+                "      \"agent_code\": \"$agent_code\",\n" +
+                "      \"city_code\": \"$city_code\"\n" +
+                "    },\n" +
+                "    \"c\": {\n" +
+                "      \"$sum\": 1\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$sort\": {\n" +
+                "    \"_id.agent_code\": 1,\n" +
+                "    \"_id.city_code\": -1\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"ac\": \"$_id.agent_code\",\n" +
+                "    \"cc\": \"$_id.city_code\",\n" +
+                "    \"c\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
+                "}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeSumGroupByWithSortFieldsWithPartialAlias() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("SELECT agent_code as ac, city_code,  \n" +
+                "COUNT (advance_amount) as c  \n" +
+                "FROM orders \n " +
+                "WHERE agent_code LIKE 'AW_%'\n" +
+                "GROUP BY agent_code, city_code\n" +
+                "ORDER BY agent_code asc, city_code DESC;");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.orders.aggregate([{\n" +
+                "  \"$match\": {\n" +
+                "    \"agent_code\": {\n" +
+                "      \"$regex\": \"^AW.{1}.*$\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$group\": {\n" +
+                "    \"_id\": {\n" + 
+                "      \"agent_code\": \"$agent_code\",\n" +
+                "      \"city_code\": \"$city_code\"\n" +
+                "    },\n" +
+                "    \"c\": {\n" +
+                "      \"$sum\": 1\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$sort\": {\n" +
+                "    \"_id.agent_code\": 1,\n" +
+                "    \"_id.city_code\": -1\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"ac\": \"$_id.agent_code\",\n" +
+                "    \"city_code\": \"$_id.city_code\",\n" +
+                "    \"c\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
                 "}])",byteArrayOutputStream.toString("UTF-8"));
     }
 
+    
+    @Test
+    public void writeSumGroupByWithSortFieldsWithPartialAliasNoCount() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("SELECT agent_code as ac, city_code,  \n" +
+                "COUNT (advance_amount) \n" +
+                "FROM orders \n " +
+                "WHERE agent_code LIKE 'AW_%'\n" +
+                "GROUP BY agent_code, city_code\n" +
+                "ORDER BY agent_code asc, city_code DESC;");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.orders.aggregate([{\n" +
+                "  \"$match\": {\n" +
+                "    \"agent_code\": {\n" +
+                "      \"$regex\": \"^AW.{1}.*$\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$group\": {\n" +
+                "    \"_id\": {\n" + 
+                "      \"agent_code\": \"$agent_code\",\n" +
+                "      \"city_code\": \"$city_code\"\n" +
+                "    },\n" +
+                "    \"count\": {\n" +
+                "      \"$sum\": 1\n" +
+                "    }\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$sort\": {\n" +
+                "    \"_id.agent_code\": 1,\n" +
+                "    \"_id.city_code\": -1\n" +
+                "  }\n" +
+                "},{\n" +
+                "  \"$project\": {\n" +
+                "    \"ac\": \"$_id.agent_code\",\n" +
+                "    \"city_code\": \"$_id.city_code\",\n" +
+                "    \"count\": 1,\n" +
+                "    \"_id\": 0\n" +
+                "  }\n" +
+                "}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
     @Test
     public void writeWithProjections() throws ParseException, IOException {
         QueryConverter queryConverter = new QueryConverter("select column1, column2 from my_table where value IS NULL");
@@ -1046,7 +1264,121 @@ public class QueryConverterTest {
                 "  \"column2\": 1\n" +
                 "})",byteArrayOutputStream.toString("UTF-8"));
     }
+    
+    @Test
+    public void writeWithProjectionsAliasSingle() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select column1 as c1, column2 from my_table where value IS NULL");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.my_table.aggregate([{\n" + 
+        		"  \"$match\": {\n" + 
+        		"    \"value\": {\n" + 
+        		"      \"$exists\": false\n" + 
+        		"    }\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$project\": {\n" + 
+        		"    \"_id\": 0,\n" + 
+        		"    \"c1\": \"$column1\",\n" + 
+        		"    \"column2\": 1\n" + 
+        		"  }\n" + 
+        		"}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeWithProjectionsAliasAll() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select column1 as c1, column2 as c2 from my_table where value IS NULL");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.my_table.aggregate([{\n" + 
+        		"  \"$match\": {\n" + 
+        		"    \"value\": {\n" + 
+        		"      \"$exists\": false\n" + 
+        		"    }\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$project\": {\n" + 
+        		"    \"_id\": 0,\n" + 
+        		"    \"c1\": \"$column1\",\n" + 
+        		"    \"c2\": \"$column2\"\n" + 
+        		"  }\n" + 
+        		"}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeWithProjectionsAliasAllSortSingle() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select column1 as c1, column2 from my_table where value IS NULL order by column1 asc");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.my_table.aggregate([{\n" + 
+        		"  \"$match\": {\n" + 
+        		"    \"value\": {\n" + 
+        		"      \"$exists\": false\n" + 
+        		"    }\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$sort\": {\n" + 
+        		"    \"column1\": 1\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$project\": {\n" + 
+        		"    \"_id\": 0,\n" + 
+        		"    \"c1\": \"$column1\",\n" + 
+        		"    \"column2\": 1\n" + 
+        		"  }\n" + 
+        		"}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
+    @Test
+    public void writeWithProjectionsAliasAllSortMixed() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select column1 as c1, column2 from my_table where value IS NULL order by column1 asc, column2");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.my_table.aggregate([{\n" + 
+        		"  \"$match\": {\n" + 
+        		"    \"value\": {\n" + 
+        		"      \"$exists\": false\n" + 
+        		"    }\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$sort\": {\n" + 
+        		"    \"column1\": 1,\n" + 
+        		"    \"column2\": 1\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$project\": {\n" + 
+        		"    \"_id\": 0,\n" + 
+        		"    \"c1\": \"$column1\",\n" + 
+        		"    \"column2\": 1\n" + 
+        		"  }\n" + 
+        		"}])",byteArrayOutputStream.toString("UTF-8"));
+    }
 
+    @Test
+    public void writeWithProjectionsAliasAllSortAll() throws ParseException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select column1 as c1, column2 as c2 from my_table where value IS NULL order by column1 asc, column2 asc");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        queryConverter.write(byteArrayOutputStream);
+        assertEquals("db.my_table.aggregate([{\n" + 
+        		"  \"$match\": {\n" + 
+        		"    \"value\": {\n" + 
+        		"      \"$exists\": false\n" + 
+        		"    }\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$sort\": {\n" + 
+        		"    \"column1\": 1,\n" + 
+        		"    \"column2\": 1\n" + 
+        		"  }\n" + 
+        		"},{\n" + 
+        		"  \"$project\": {\n" + 
+        		"    \"_id\": 0,\n" + 
+        		"    \"c1\": \"$column1\",\n" + 
+        		"    \"c2\": \"$column2\"\n" + 
+        		"  }\n" + 
+        		"}])",byteArrayOutputStream.toString("UTF-8"));
+    }
+    
     @Test
     public void doubleEquals() throws ParseException {
         expectedException.expect(ParseException.class);
@@ -1139,6 +1471,67 @@ public class QueryConverterTest {
         assertEquals(0,mongoDBQueryHolder.getProjection().size());
         assertEquals("my_table",mongoDBQueryHolder.getCollection());
         assertEquals(document("a.b.c.d.e.key", "value"),mongoDBQueryHolder.getQuery());
+    }
+    
+    @Test
+    public void aliasPlainQuery() throws ParseException {
+        QueryConverter queryConverter = new QueryConverter("select aa as bb, cc from my_table where aa = value and cc = value");
+        MongoDBQueryHolder mongoDBQueryHolder = queryConverter.getMongoQuery();
+        assertEquals(document("_id",0).append("bb","$aa").append("cc",1),mongoDBQueryHolder.getProjection());
+        assertEquals("my_table",mongoDBQueryHolder.getCollection());
+        assertEquals(document("$and",document("aa","value"),document("cc","value")),mongoDBQueryHolder.getQuery());
+    }
+    
+    @Test
+    public void aliasGroupQuerySingleGroup() throws ParseException {
+        QueryConverter queryConverter = new QueryConverter("select aa as bb, count(*) as dd from my_table where aa = value group by aa");
+        MongoDBQueryHolder mongoDBQueryHolder = queryConverter.getMongoQuery();
+        assertEquals(2,mongoDBQueryHolder.getProjection().size());
+        assertEquals(document("_id","$aa").append("dd", document("$sum",1)),mongoDBQueryHolder.getProjection());
+        assertEquals(3,mongoDBQueryHolder.getAliasProjection().size());
+        assertEquals(document("bb","$_id").append("_id", 0).append("dd", 1),mongoDBQueryHolder.getAliasProjection());
+        assertEquals("my_table",mongoDBQueryHolder.getCollection());
+        assertEquals(document("aa","value"),mongoDBQueryHolder.getQuery());
+        assertEquals(Arrays.asList(new String[]{"aa"}),mongoDBQueryHolder.getGroupBys());
+    }
+    
+    @Test
+    public void aliasGroupQueryAliasAndNot() throws ParseException {
+        QueryConverter queryConverter = new QueryConverter("select aa as bb, cc, count(*) as dd from my_table where aa = value group by aa, cc");
+        MongoDBQueryHolder mongoDBQueryHolder = queryConverter.getMongoQuery();
+        assertEquals(2,mongoDBQueryHolder.getProjection().size());
+        assertEquals(document("_id",document("aa","$aa").append("cc","$cc")).append("dd", document("$sum",1)),mongoDBQueryHolder.getProjection());
+        assertEquals(4,mongoDBQueryHolder.getAliasProjection().size());
+        assertEquals(document("bb","$_id.aa").append("cc", "$_id.cc").append("_id", 0).append("dd", 1),mongoDBQueryHolder.getAliasProjection());
+        assertEquals("my_table",mongoDBQueryHolder.getCollection());
+        assertEquals(document("aa","value"),mongoDBQueryHolder.getQuery());
+        assertEquals(Arrays.asList(new String[]{"aa","cc"}),mongoDBQueryHolder.getGroupBys());
+    }
+    
+    @Test
+    public void aliasGroupQueryNoGroupAlias() throws ParseException {
+        QueryConverter queryConverter = new QueryConverter("select aa as bb, cc, count(*) from my_table where aa = value group by aa, cc");
+        MongoDBQueryHolder mongoDBQueryHolder = queryConverter.getMongoQuery();
+        assertEquals(2,mongoDBQueryHolder.getProjection().size());
+        assertEquals(document("_id",document("aa","$aa").append("cc","$cc")).append("count", document("$sum",1)),mongoDBQueryHolder.getProjection());
+        assertEquals(4,mongoDBQueryHolder.getAliasProjection().size());
+        assertEquals(document("bb","$_id.aa").append("cc", "$_id.cc").append("_id", 0).append("count", 1),mongoDBQueryHolder.getAliasProjection());
+        assertEquals("my_table",mongoDBQueryHolder.getCollection());
+        assertEquals(document("aa","value"),mongoDBQueryHolder.getQuery());
+        assertEquals(Arrays.asList(new String[]{"aa","cc"}),mongoDBQueryHolder.getGroupBys());
+    }
+    
+    @Test
+    public void aliasGroupQueryAllAlias() throws ParseException {
+        QueryConverter queryConverter = new QueryConverter("select aa as bb, cc as dd, count(*) as ee from my_table where aa = value group by aa, cc");
+        MongoDBQueryHolder mongoDBQueryHolder = queryConverter.getMongoQuery();
+        assertEquals(2,mongoDBQueryHolder.getProjection().size());
+        assertEquals(document("_id",document("aa","$aa").append("cc","$cc")).append("ee", document("$sum",1)),mongoDBQueryHolder.getProjection());
+        assertEquals(4,mongoDBQueryHolder.getAliasProjection().size());
+        assertEquals(document("bb","$_id.aa").append("dd", "$_id.cc").append("_id", 0).append("ee", 1),mongoDBQueryHolder.getAliasProjection());
+        assertEquals("my_table",mongoDBQueryHolder.getCollection());
+        assertEquals(document("aa","value"),mongoDBQueryHolder.getQuery());
+        assertEquals(Arrays.asList(new String[]{"aa","cc"}),mongoDBQueryHolder.getGroupBys());
     }
 
     private static Document document(String key, Object... values) {


### PR DESCRIPTION
Hi vincentrussell, 
 
I’m a member of onesait Platform’s team (an OpenSource Platform from Minsait company in Spain). You can get more information here https://onesaitplatform.atlassian.net/wiki/spaces/OP/overview?mode=global and in our github https://github.com/onesaitplatform. We’re very interested in develop more your fantastic sqltomongo query converter, so I ask you to review this pull-request in order to contribute to your repository.
 
This pull-request enable alias for project fields in queries. The way to do this, it’s using the SQL standard alias:
 
Select field1 as alias1, field2 as alias2 from table
 
Field’s alias has a new $project stage in Group queries, in order to rename all fields into the required ones. Other alias queries are transform into the aggregate equivalent and it’s added the $project stage to perform the alias transform.
