### PR TITLE
Feature/offset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.7</jdk.version>
     <slf4j.version>1.6.1</slf4j.version>
-    <mongodb.version>3.3.0</mongodb.version>
+    <mongodb.version>3.12.0</mongodb.version>
   </properties>
 
   <dependencyManagement>
@@ -129,7 +129,7 @@
       <dependency>
         <groupId>de.flapdoodle.embed</groupId>
         <artifactId>de.flapdoodle.embed.mongo</artifactId>
-        <version>1.50.5</version>
+        <version>2.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>
@@ -200,7 +200,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>1.50.5</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/MongoDBQueryHolder.java
+++ b/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/MongoDBQueryHolder.java
@@ -19,6 +19,7 @@ public class MongoDBQueryHolder {
     private boolean countAll = false;
     private List<String> groupBys = new ArrayList<>();
     private long limit = -1;
+    private long offset = -1;
 
     /**
      * Pojo to hold the MongoDB data
@@ -112,6 +113,14 @@ public class MongoDBQueryHolder {
 
     public void setLimit(long limit) {
         this.limit = limit;
+    }
+    
+    public long getOffset() {
+        return offset;
+    }
+
+    public void setOffset(long offset) {
+        this.offset = offset;
     }
 
     public SQLCommandType getSqlCommandType() {

--- a/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/SQLCommandInfoHolder.java
+++ b/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/SQLCommandInfoHolder.java
@@ -19,6 +19,7 @@ public class SQLCommandInfoHolder {
     private final boolean isCountAll;
     private final String table;
     private final long limit;
+    private final long offset;
     private final Expression whereClause;
     private final List<SelectItem> selectItems;
     private final List<Join> joins;
@@ -27,13 +28,14 @@ public class SQLCommandInfoHolder {
     private final HashMap<String,String> aliasHash;
 
     public SQLCommandInfoHolder(SQLCommandType sqlCommandType, Expression whereClause,
-                                boolean isDistinct, boolean isCountAll, String table, long limit, List<SelectItem> selectItems, List<Join> joins, List<String> groupBys, List<OrderByElement> orderByElements, HashMap<String,String> aliasHash) {
+                                boolean isDistinct, boolean isCountAll, String table, long limit, long offset, List<SelectItem> selectItems, List<Join> joins, List<String> groupBys, List<OrderByElement> orderByElements, HashMap<String,String> aliasHash) {
         this.sqlCommandType = sqlCommandType;
         this.whereClause = whereClause;
         this.isDistinct = isDistinct;
         this.isCountAll = isCountAll;
         this.table = table;
         this.limit = limit;
+        this.offset = offset;
         this.selectItems = selectItems;
         this.joins = joins;
         this.groupBys = groupBys;
@@ -55,6 +57,10 @@ public class SQLCommandInfoHolder {
 
     public long getLimit() {
         return limit;
+    }
+    
+    public long getOffset() {
+        return offset;
     }
 
     public Expression getWhereClause() {
@@ -94,6 +100,7 @@ public class SQLCommandInfoHolder {
         private boolean isCountAll = false;
         private String table;
         private long limit = -1;
+        private long offset = -1;
         private List<SelectItem> selectItems = new ArrayList<>();
         private List<Join> joins = new ArrayList<>();
         private List<String> groupBys = new ArrayList<>();
@@ -118,6 +125,7 @@ public class SQLCommandInfoHolder {
                 SqlUtils.isTrue(plainSelect.getFromItem() != null, "could not find table to query.  Only one simple table name is supported.");
                 table = plainSelect.getFromItem().toString();
                 limit = SqlUtils.getLimit(plainSelect.getLimit());
+                offset = SqlUtils.getOffset(plainSelect.getOffset());
                 orderByElements1 = plainSelect.getOrderByElements();
                 selectItems = plainSelect.getSelectItems();
                 joins = plainSelect.getJoins();
@@ -149,7 +157,7 @@ public class SQLCommandInfoHolder {
 
         public SQLCommandInfoHolder build() {
             return new SQLCommandInfoHolder(sqlCommandType, whereClause,
-                    isDistinct, isCountAll, table, limit, selectItems, joins, groupBys, orderByElements1, aliasHash);
+                    isDistinct, isCountAll, table, limit, offset, selectItems, joins, groupBys, orderByElements1, aliasHash);
         }
 
         public static Builder create(FieldType defaultFieldType, Map<String, FieldType> fieldNameToFieldTypeMapping) {

--- a/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/util/SqlUtils.java
+++ b/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/util/SqlUtils.java
@@ -144,13 +144,23 @@ public class SqlUtils {
         }
         throw new ParseException("could not normalize value:" + value);
     }
+    
+    private static long getLongFromStringIfInteger(String svalue) throws ParseException {
+        BigInteger bigInt = new BigInteger(svalue);
+        isFalse(bigInt.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0, svalue + ": value is too large");
+        return bigInt.longValue();
+    }
 
     public static long getLimit(Limit limit) throws ParseException {
         if (limit!=null) {
-            String rowCountString = SqlUtils.getStringValue(limit.getRowCount());
-            BigInteger bigInt = new BigInteger(rowCountString);
-            isFalse(bigInt.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0, rowCountString + ": value is too large");
-            return bigInt.longValue();
+        	return getLongFromStringIfInteger(SqlUtils.getStringValue(limit.getRowCount()));
+        }
+        return -1;
+    }
+    
+    public static long getOffset(Offset offset) {
+        if (offset!=null) {
+            return offset.getOffset();
         }
         return -1;
     }

--- a/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
+++ b/src/test/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverterIT.java
@@ -308,6 +308,30 @@ public class QueryConverterIT {
     }
     
     @Test
+    public void selectOrderByQueryOffset() throws ParseException, IOException, JSONException {
+        QueryConverter queryConverter = new QueryConverter("select borough, cuisine from "+COLLECTION+" order by borough asc,cuisine desc limit 5 offset 5");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(5, results.size());
+        JSONAssert.assertEquals("[{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"},{\n" + 
+        		"	\"borough\" : \"Bronx\",\n" + 
+        		"	\"cuisine\" : \"Tex-Mex\"\n" + 
+        		"}]",toJson(results),false);
+    }
+    
+    @Test
     public void selectOrderByAliasQuery() throws ParseException, IOException, JSONException {
         QueryConverter queryConverter = new QueryConverter("select borough as b, cuisine as c from "+COLLECTION+" order by borough asc,cuisine asc limit 6");
         QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
@@ -474,6 +498,25 @@ public class QueryConverterIT {
     }
     
     @Test
+    public void countGroupByNestedFieldSortByCountAliasAllQueryOffset() throws ParseException, IOException, JSONException {
+        QueryConverter queryConverter = new QueryConverter("select address.zipcode as az, count(borough) as co from "+COLLECTION+" GROUP BY address.zipcode order by address.zipcode asc limit 3 offset 3\n" +
+                "ORDER BY count(borough) DESC;");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(3, results.size());
+        JSONAssert.assertEquals("[{\n" + 
+        		"	\"co\" : 520,\n" + 
+        		"	\"az\" : \"10001\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 471,\n" + 
+        		"	\"az\" : \"10002\"\n" + 
+        		"},{\n" + 
+        		"	\"co\" : 686,\n" + 
+        		"	\"az\" : \"10003\"\n" + 
+        		"}]",toJson(results),false);
+    }
+    
+    @Test
     public void countGroupByNestedFieldSortByCountQuery() throws ParseException, IOException, JSONException {
         QueryConverter queryConverter = new QueryConverter("select address.zipcode, count(borough) as co from "+COLLECTION+" GROUP BY address.zipcode order by address.zipcode limit 6\n" +
                 "ORDER BY count(borough) DESC;");
@@ -521,6 +564,16 @@ public class QueryConverterIT {
         assertEquals(2, results.size());
         JSONAssert.assertEquals(toJson(Arrays.asList(new Document("count",2338).append("borough","Bronx"),
                 new Document("count",6086).append("borough","Brooklyn")
+        )),toJson(results),false);
+    }
+    
+    @Test
+    public void countGroupByQueryLimitOffset() throws ParseException, JSONException, IOException {
+        QueryConverter queryConverter = new QueryConverter("select borough, count(borough) from "+COLLECTION+" GROUP BY borough order by borough asc LIMIT 1 OFFSET 1");
+        QueryResultIterator<Document> distinctIterable = queryConverter.run(mongoDatabase);
+        List<Document> results = Lists.newArrayList(distinctIterable);
+        assertEquals(1, results.size());
+        JSONAssert.assertEquals(toJson(Arrays.asList(new Document("count",6086).append("borough","Brooklyn")
         )),toJson(results),false);
     }
 


### PR DESCRIPTION
Hi again,

This pull request enable offset feature with .skip() step in normal query and with aggregate "$skip" step in grouped queries.

The way to use it, it's SQL standard like this:

select * from table limit 3 offset 4
or
select a, count(*) from table group by a limit 3 offset 4

Also, I update the mongo driver to the lastest version (3.12) and set test with embedded mongo 4.2.2