### PR TITLE
Add support for functions in the projection clause

### DIFF
--- a/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverter.java
+++ b/src/main/java/com/github/vincentrussell/query/mongodb/sql/converter/QueryConverter.java
@@ -33,6 +33,7 @@ import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.Function;
 import net.sf.jsqlparser.expression.NullValue;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.parser.CCJSqlParser;
 import net.sf.jsqlparser.parser.StreamProvider;
 import net.sf.jsqlparser.schema.Column;
@@ -134,8 +135,8 @@ public final class QueryConverter {
                     @Override
                     public boolean apply(final SelectItem selectItem) {
                         try {
-                            if (SelectExpressionItem.class.isInstance(selectItem)
-                                    && Column.class.isInstance(((SelectExpressionItem) selectItem).getExpression())) {
+                            if (SelectExpressionItem.class.isInstance(selectItem)) {
+//                                    && Column.class.isInstance(((SelectExpressionItem) selectItem).getExpression())) {
                                 return true;
                             }
                         } catch (NullPointerException e) {
@@ -155,7 +156,8 @@ public final class QueryConverter {
                 || SqlUtils.isSelectAll(selectItems))
                 && sqlCommandInfoHolder.isDistinct(), "cannot run distinct one more than one column");
         SqlUtils.isFalse(sqlCommandInfoHolder.getGroupBys().size() == 0
-                        && selectItems.size() != filteredItems.size() && !SqlUtils.isSelectAll(selectItems)
+                        && selectItems.size() != filteredItems.size()
+                        && !SqlUtils.isSelectAll(selectItems)
                         && !SqlUtils.isCountAll(selectItems)
                         && !sqlCommandInfoHolder.isTotalGroup(),
                 "illegal expression(s) found in select clause.  Only column names supported");
@@ -237,6 +239,14 @@ public final class QueryConverter {
                             (alias != null ? "$" + columnName : 1));
                 } else if (selectExpressionItem.getExpression() instanceof SubSelect) {
                     throw new ParseException("Unsupported subselect expression");
+                } else if (selectExpressionItem.getExpression() instanceof Function) {
+                    Function f = (Function) selectExpressionItem.getExpression();
+                    String columnName = f.toString();
+                    Alias alias = selectExpressionItem.getAlias();
+                    String key = (alias != null ? alias.getName() : columnName);
+                    Document functionDoc = (Document) recurseFunctions(new Document(), f,
+                            defaultFieldType, fieldNameToFieldTypeMapping);
+                    document.put(key, functionDoc);
                 } else {
                     throw new ParseException("Unsupported project expression");
                 }
@@ -322,6 +332,35 @@ public final class QueryConverter {
         mongoDBQueryHolder.setLimit(sqlCommandInfoHolder.getLimit());
 
         return mongoDBQueryHolder;
+    }
+
+    protected Object recurseFunctions(final Document query, final Object object,
+                                      final FieldType defaultFieldType,
+                                      final Map<String, FieldType> fieldNameToFieldTypeMapping) throws ParseException {
+        if (Function.class.isInstance(object)) {
+            Function function = (Function) object;
+            query.put("$" + SqlUtils.translateFunctionName(function.getName()),
+                    recurseFunctions(new Document(), function.getParameters(),
+                            defaultFieldType, fieldNameToFieldTypeMapping));
+        } else if (ExpressionList.class.isInstance(object)) {
+            ExpressionList expressionList = (ExpressionList) object;
+            List<Object> objectList = new ArrayList<>();
+            for (Expression expression : expressionList.getExpressions()) {
+                objectList.add(recurseFunctions(new Document(), expression,
+                        defaultFieldType, fieldNameToFieldTypeMapping));
+            }
+            return objectList.size() == 1 ? objectList.get(0) : objectList;
+        } else if (Expression.class.isInstance(object)) {
+            Object normalizedValue = SqlUtils.getNormalizedValue((Expression) object, null,
+                    defaultFieldType, fieldNameToFieldTypeMapping, null);
+            if (Column.class.isInstance(object)) {
+                return "$" + ((String)normalizedValue);
+            } else {
+                return normalizedValue;
+            }
+        }
+
+        return query.isEmpty() ? null : query;
     }
 
     private Expression preprocessWhere(final Expression exp, final FromHolder tholder) {


### PR DESCRIPTION
Hi Vincent,
Thanks for this great work. I also need functions in my project clause. I hacked a bit to get it working in a way that meets my needs. Below is an example of how I have it working:

select id,sin(temperature) as temp from GasRecordV1;

******Mongo Query:*********

db.GasRecordV1.aggregate([{
  "$project": {
    "_id": 0,
    "id": 1,
    "temp": {
      "$sin": "$temperature"
    }
  }
}])
All of the unit tests pass, but the biggest thing I am not sure about right now is how I just brutally chopped off the validation for all select items being a column around line 140 of Query Converter (line may have changed due to other changes). I also borrowed the recurse function code from the WhereClauseProcessor. And re-used the getNormalizedValue, but manually tack on a $ if the type is a column so the expression works.

Happy to submit a PR if interested.

Thanks!